### PR TITLE
Add GIT_TAG to setGitEnvironmentVariables

### DIFF
--- a/vars/setGitEnvironmentVariables.groovy
+++ b/vars/setGitEnvironmentVariables.groovy
@@ -2,4 +2,9 @@ def call() {
   env.GIT_COMMIT = sh([returnStdout: true, script: 'git rev-parse HEAD']).trim()
   env.GIT_COMMIT_SHORT = env.GIT_COMMIT.take(6)
   env.GIT_BRANCH = getGitBranch()
+  try {
+    env.GIT_TAG = sh([returnStdout: true, script: 'git describe --tags --exact-match $GIT_COMMIT']).trim()
+  } catch(e) {
+    echo 'git commit not tagged'
+  }
 }


### PR DESCRIPTION
I tested this in the bedrock pipeline, but feel free to give it a try as well. Should set the GIT_TAG env var if the current GIT_COMMIT is tagged, else GIT_TAG should not be set.