### PR TITLE
Don't hardcode default Docker registry.

### DIFF
--- a/vars/dockerImagePush.groovy
+++ b/vars/dockerImagePush.groovy
@@ -24,5 +24,5 @@ def call(String image_id, String registry, String credentials) {
 
 
 def call(String image_id, String credentials) {
-  push(image_id, "https://registry.hub.docker.com", credentials)
+  push(image_id, "", credentials)
 }


### PR DESCRIPTION
Apparently, the default Docker registry used when running `docker login` has changed over time. This repository uses the old value. Newer versions of the Docker CLI use https://index.docker.io/v1/ instead.

The result is that subequent calls to `docker push` that do not specify a registry will fail, since they don't find credentials for the default registry.

Rather than harcdoding the value of the default registry, this change uses the empty string instead. I tested that explicitly passing '' as the server URL works fine and results in the default registry being used.